### PR TITLE
LL-1392 Send max mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ledgerhq/hw-app-xrp": "4.61.0",
     "@ledgerhq/hw-transport": "4.61.0",
     "@ledgerhq/hw-transport-http": "4.61.0",
-    "@ledgerhq/live-common": "^6.3.0",
+    "@ledgerhq/live-common": "^6.4.0",
     "@ledgerhq/logs": "^4.61.0",
     "@ledgerhq/react-native-hid": "4.61.0",
     "@ledgerhq/react-native-hw-transport-ble": "4.61.0",

--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -148,6 +148,7 @@ class CurrencyInput extends PureComponent<Props, State> {
             styles.input,
             isActive ? styles.active : null,
             hasError ? styles.error : null,
+            editable ? null : styles.readOnly,
           ]}
           editable={editable}
           onChangeText={this.handleChange}
@@ -190,6 +191,9 @@ const styles = StyleSheet.create({
   },
   error: {
     color: colors.alert,
+  },
+  readOnly: {
+    color: colors.grey,
   },
 });
 

--- a/src/context/AuthPass/methods/biometry.js
+++ b/src/context/AuthPass/methods/biometry.js
@@ -2,6 +2,6 @@ import TouchID from "react-native-touch-id";
 import { Platform } from "react-native";
 import unsupported from "./unsupported";
 
-export default (Platform.OS === "android" && Platform.Version < 23
+export default Platform.OS === "android" && Platform.Version < 23
   ? unsupported
-  : TouchID);
+  : TouchID;

--- a/src/experimental.js
+++ b/src/experimental.js
@@ -51,6 +51,12 @@ export const experimentalFeatures: Feature[] = [
     title: "Experimental Core",
     description: "Enable experimental Ledger lib-core features.",
   },
+  {
+    type: "toggle",
+    name: "EXPERIMENTAL_SEND_MAX",
+    title: "Experimental Send Max",
+    description: "Enable support for send max feature.",
+  },
 ];
 
 const storageKey = "experimentalFlags";

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -839,7 +839,8 @@
       "input": "Enter address"
     },
     "amount": {
-      "available": "<1><0>{{amount}}</></> available",
+      "available": "Total available",
+      "useMax": "Use max",
       "loadingNetwork": "Loading Network fees...",
       "noRateProvider": "Not available"
     },

--- a/src/logic/extraStatusBarPadding.js
+++ b/src/logic/extraStatusBarPadding.js
@@ -1,8 +1,8 @@
 import { Platform } from "react-native";
 import ExtraDimensions from "react-native-extra-dimensions-android";
 
-export default (Platform.OS === "ios"
+export default Platform.OS === "ios"
   ? parseInt(Platform.Version, 10) < 11
     ? 16
     : 0
-  : ExtraDimensions.get("STATUS_BAR_HEIGHT"));
+  : ExtraDimensions.get("STATUS_BAR_HEIGHT");

--- a/src/screens/ImportAccounts/DisplayResult.js
+++ b/src/screens/ImportAccounts/DisplayResult.js
@@ -107,42 +107,38 @@ class DisplayResult extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     const items = nextProps.navigation
       .getParam("result")
-      .accounts.map(
-        (accInput: *): ?Item => {
-          const prevItem = prevState.items.find(
-            item => item.account.id === accInput.id,
-          );
-          if (prevItem) return prevItem;
-          const existingAccount = nextProps.accounts.find(
-            a => a.id === accInput.id,
-          );
-          if (existingAccount) {
-            // only the name is supposed to change. rest is never changing
-            if (existingAccount.name === accInput.name) {
-              return {
-                account: existingAccount,
-                mode: "id",
-              };
-            }
+      .accounts.map((accInput: *): ?Item => {
+        const prevItem = prevState.items.find(
+          item => item.account.id === accInput.id,
+        );
+        if (prevItem) return prevItem;
+        const existingAccount = nextProps.accounts.find(
+          a => a.id === accInput.id,
+        );
+        if (existingAccount) {
+          // only the name is supposed to change. rest is never changing
+          if (existingAccount.name === accInput.name) {
             return {
-              account: { ...existingAccount, name: accInput.name },
-              mode: "patch",
+              account: existingAccount,
+              mode: "id",
             };
           }
-          try {
-            const account = accountDataToAccount(accInput);
-            return {
-              account,
-              mode: supportsExistingAccount(accInput)
-                ? "create"
-                : "unsupported",
-            };
-          } catch (e) {
-            logger.critical(e);
-            return null;
-          }
-        },
-      )
+          return {
+            account: { ...existingAccount, name: accInput.name },
+            mode: "patch",
+          };
+        }
+        try {
+          const account = accountDataToAccount(accInput);
+          return {
+            account,
+            mode: supportsExistingAccount(accInput) ? "create" : "unsupported",
+          };
+        } catch (e) {
+          logger.critical(e);
+          return null;
+        }
+      })
       .filter(Boolean)
       .sort(
         (a, b) => itemModeDisplaySort[a.mode] - itemModeDisplaySort[b.mode],

--- a/src/screens/SendFunds/AmountInput.js
+++ b/src/screens/SendFunds/AmountInput.js
@@ -30,6 +30,7 @@ type OwnProps = {
   value: BigNumber,
   onChange: BigNumber => void,
   error?: Error,
+  editable?: boolean,
 };
 
 type Props = OwnProps & {
@@ -48,6 +49,10 @@ class AmountInput extends Component<Props, OwnState> {
 
   state = {
     active: "crypto",
+  };
+
+  static defaultProps = {
+    editable: true,
   };
 
   componentDidMount() {
@@ -95,6 +100,7 @@ class AmountInput extends Component<Props, OwnState> {
       getCounterValue,
       account,
       error,
+      editable,
     } = this.props;
     const isCrypto = active === "crypto";
     const fiat = value ? getCounterValue(value) : BigNumber(0);
@@ -104,6 +110,7 @@ class AmountInput extends Component<Props, OwnState> {
         <View style={styles.wrapper}>
           <CurrencyInput
             isActive={isCrypto}
+            editable={editable}
             onFocus={this.onCryptoFieldFocus}
             onChange={this.onCryptoFieldChange}
             unit={account.unit}
@@ -131,7 +138,7 @@ class AmountInput extends Component<Props, OwnState> {
             unit={rightUnit}
             value={value ? fiat : null}
             placeholder={!fiat ? t("send.amount.noRateProvider") : undefined}
-            editable={!!fiat}
+            editable={!!fiat && editable}
             showAllDigits
             renderRight={
               <LText

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,10 +791,10 @@
     "@ledgerhq/errors" "^4.61.0"
     events "^3.0.0"
 
-"@ledgerhq/live-common@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-6.3.0.tgz#d508211d6a78bf4555433d6127b0287041013661"
-  integrity sha512-qNd/eiAzX61rJsue9K0CJweFxbtmhcSDOk8HaauyMSdRgxhjtPg4eAggjYkfojOGKK98eSJtPeEzaeTlEcBrYg==
+"@ledgerhq/live-common@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-6.4.0.tgz#e4ec53994c28a1968f315fa45abbcd02d8b8129f"
+  integrity sha512-guyLHxTi3U2X3a2e+dGxEU7en9WkgZzsUgLtLnuB8NQjwxjpa8ifhUKVSFsZGWh0rKQqG+ZcI797cGJlGMjg+A==
   dependencies:
     "@ledgerhq/errors" "4.61.0"
     "@ledgerhq/hw-app-btc" "4.61.0"
@@ -819,7 +819,7 @@
     ripple-binary-codec "^0.2.0"
     ripple-bs58check "^2.0.2"
     ripple-hashes "^0.3.1"
-    ripple-lib "^1.2.3"
+    ripple-lib "^1.2.4"
     rxjs "^6.5.2"
     rxjs-compat "^6.5.2"
 
@@ -7858,7 +7858,7 @@ ripple-lib-transactionparser@0.7.1:
     bignumber.js "^4.1.0"
     lodash "^4.17.4"
 
-ripple-lib@^1.2.3:
+ripple-lib@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ripple-lib/-/ripple-lib-1.2.4.tgz#834c318aae1a255beb9a57bc2b36a08cf9226019"
   integrity sha512-hmlj+AIisg4XuSS4ee4uhB9Glc/kM02ZNfl7KF336NDPu81vhqJuR8pikSGwJ/Ay7wIVrP9ny1zR/6FI6lZTZg==


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/59289197-c410ac00-8c75-11e9-92ea-db36b34e7920.png)

With https://github.com/LedgerHQ/ledger-live-common/pull/270 merged, we need a new version of common to get the changes on this PR

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1392

### Parts of the app affected / Test plan

Send flow. It's an experimental feature so it needs to be enabled first.

- Disabling Use Max should reset the amount to 0.
- Enabling Use Max should render the amount inputs non editable.
- Right now, it should only appear on libcore handled currencies, ie not in eth or xrp for instance.
